### PR TITLE
Only validate the username once.

### DIFF
--- a/devchat.go
+++ b/devchat.go
@@ -58,7 +58,8 @@ type user struct {
 	bell          bool
 	pingEverytime bool
 	color         string
-	id            string
+	uid           string
+	cid           string
 	addr          string
 	win           ssh.Window
 	closeOnce     sync.Once
@@ -112,6 +113,10 @@ func main() {
 		}()
 		u.repl()
 	})
+	publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
+	})
+
 	var err error
 	if os.Getenv("PORT") != "" {
 		port, err = strconv.Atoi(os.Getenv("PORT"))
@@ -131,7 +136,7 @@ func main() {
 			}
 		}
 	}()
-	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"))
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), publicKeyOption)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -183,15 +188,22 @@ func newUser(s ssh.Session) *user {
 	pty, winChan, _ := s.Pty()
 	w := pty.Window
 	host, _, _ := net.SplitHostPort(s.RemoteAddr().String()) // definitely should not give an err
-	hash := sha256.New()
-	hash.Write([]byte(host))
+	ip_hash := sha256.New()
+	config_hash := sha256.New()
+	pubkey := s.PublicKey()
+	if pubkey != nil {
+		config_hash.Write([]byte(pubkey.Marshal()))
+	} else { // If we can't get the public key fall back to the IP.
+		ip_hash.Write([]byte(host))
+	}
 
 	u := &user{
 		name:          s.User(),
 		session:       s,
 		term:          term,
 		bell:          true,
-		id:            hex.EncodeToString(hash.Sum(nil)),
+		uid:           hex.EncodeToString(ip_hash.Sum(nil)),     // User ID = IP
+		cid:           hex.EncodeToString(config_hash.Sum(nil)), // Config ID = Pubkey
 		addr:          host,
 		win:           w,
 		lastTimestamp: time.Now(),
@@ -205,25 +217,25 @@ func newUser(s ssh.Session) *user {
 		}
 	}()
 
-	l.Println("Connected " + u.name + " [" + u.id + "]")
+	l.Println("Connected " + u.name + " [" + u.uid + "]")
 
 	for i := range bans {
-		if u.addr == bans[i] || u.id == bans[i] { // allow banning by ID
-			if u.id == bans[i] { // then replace the ID in the ban with the actual IP
+		if u.addr == bans[i] || u.uid == bans[i] { // allow banning by ID
+			if u.uid == bans[i] { // then replace the ID in the ban with the actual IP
 				bans[i] = u.addr
 				saveBans()
 			}
 			l.Println("Rejected " + u.name + " [" + u.addr + "]")
-			u.writeln(devbot, "**You are banned**. If you feel this was done wrongly, please reach out at github.com/quackduck/devzat/issues. Please include the following information: [ID "+u.id+"]")
+			u.writeln(devbot, "**You are banned**. If you feel this was done wrongly, please reach out at github.com/quackduck/devzat/issues. Please include the following information: [ID "+u.uid+"]")
 			u.close("")
 			return nil
 		}
 	}
-	idsInMinToTimes[u.id]++
+	idsInMinToTimes[u.uid]++
 	time.AfterFunc(60*time.Second, func() {
-		idsInMinToTimes[u.id]--
+		idsInMinToTimes[u.uid]--
 	})
-	if idsInMinToTimes[u.id] > 6 {
+	if idsInMinToTimes[u.uid] > 6 {
 		bans = append(bans, u.addr)
 		mainRoom.broadcast(devbot, u.name+" has been banned automatically. IP: "+u.addr)
 		return nil
@@ -324,14 +336,18 @@ func (u *user) rWriteln(msg string) {
 func (u *user) pickUsername(possibleName string) (ok bool) {
 	possibleName = cleanName(possibleName)
 	var err error
-	for possibleName == "" || possibleName == "devbot" || strings.HasPrefix(possibleName, "#") || userDuplicate(u.room, possibleName) {
+	for {
 		if possibleName == "" {
 			u.writeln("", "No username chosen. Pick one:")
-		} else if strings.HasPrefix(possibleName, "#") {
+		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
 			u.writeln("", "Your username is invalid. Pick a different one:")
-		} else {
+		} else if userDuplicate(u.room, possibleName) {
 			u.writeln("", "Your username is already in use. Pick a different one:")
+		} else {
+			possibleName = cleanName(possibleName)
+			break
 		}
+
 		u.term.SetPrompt("> ")
 		possibleName, err = u.term.ReadLine()
 		if err != nil {
@@ -340,6 +356,7 @@ func (u *user) pickUsername(possibleName string) (ok bool) {
 		}
 		possibleName = cleanName(possibleName)
 	}
+
 	u.name = possibleName
 	idx := rand.Intn(len(styles) * 140 / 100) // 40% chance of a random color
 	if idx >= len(styles) {                   // allow the possibility of having a completely random RGB color
@@ -383,11 +400,11 @@ func (u *user) repl() {
 		}
 		u.term.Write([]byte(strings.Repeat("\033[A\033[2K", int(math.Ceil(float64(lenString(u.name+line)+2)/(float64(u.win.Width))))))) // basically, ceil(length of line divided by term width)
 
-		antispamMessages[u.id]++
+		antispamMessages[u.uid]++
 		time.AfterFunc(5*time.Second, func() {
-			antispamMessages[u.id]--
+			antispamMessages[u.uid]--
 		})
-		if antispamMessages[u.id] >= 50 {
+		if antispamMessages[u.uid] >= 50 {
 			if !stringsContain(bans, u.addr) {
 				bans = append(bans, u.addr)
 				saveBans()


### PR DESCRIPTION
Instead of validating the username twice, once to check if it's valid and the other to give the error message, we can do the validation at once and report the message accordingly.