### PR TITLE
Only validate the username once.

### DIFF
--- a/devchat.go
+++ b/devchat.go
@@ -321,17 +321,22 @@ func (u *user) rWriteln(msg string) {
 	}
 }
 
+
 func (u *user) pickUsername(possibleName string) (ok bool) {
 	possibleName = cleanName(possibleName)
 	var err error
-	for possibleName == "" || possibleName == "devbot" || strings.HasPrefix(possibleName, "#") || userDuplicate(u.room, possibleName) {
+	for {
 		if possibleName == "" {
 			u.writeln("", "No username chosen. Pick one:")
-		} else if strings.HasPrefix(possibleName, "#") {
+		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
 			u.writeln("", "Your username is invalid. Pick a different one:")
-		} else {
+		} else if userDuplicate(u.room, possibleName) {
 			u.writeln("", "Your username is already in use. Pick a different one:")
+		} else {
+			possibleName = cleanName(possibleName)
+			break
 		}
+
 		u.term.SetPrompt("> ")
 		possibleName, err = u.term.ReadLine()
 		if err != nil {
@@ -340,6 +345,7 @@ func (u *user) pickUsername(possibleName string) (ok bool) {
 		}
 		possibleName = cleanName(possibleName)
 	}
+
 	u.name = possibleName
 	idx := rand.Intn(len(styles) * 140 / 100) // 40% chance of a random color
 	if idx >= len(styles) {                   // allow the possibility of having a completely random RGB color


### PR DESCRIPTION
Instead of validating the username twice, once to check if it's valid and the other to give the error message, we can do the validation at once and report the message accordingly.